### PR TITLE
[WFLY-8275][JBEAP- 8993] jca inflow transactions integration with new wfly txn client

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/bootstrap/BootStrapContextService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/bootstrap/BootStrapContextService.java
@@ -26,6 +26,7 @@ import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
 
 import org.jboss.as.connector.subsystems.jca.JcaSubsystemConfiguration;
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.api.bootstrap.CloneableBootstrapContext;
 import org.jboss.jca.core.api.workmanager.WorkManager;
 import org.jboss.jca.core.bootstrapcontext.BootstrapContextCoordinator;
@@ -36,7 +37,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.msc.value.Value;
-import org.jboss.tm.JBossXATerminator;
 
 /**
  * A DefaultBootStrapContextService Service
@@ -54,7 +54,7 @@ public final class BootStrapContextService implements Service<CloneableBootstrap
 
     private final InjectedValue<com.arjuna.ats.jbossatx.jta.TransactionManagerService> txManager = new InjectedValue<com.arjuna.ats.jbossatx.jta.TransactionManagerService>();
 
-    private final InjectedValue<JBossXATerminator> xaTerminator = new InjectedValue<JBossXATerminator>();
+    private final InjectedValue<JBossContextXATerminator> xaTerminator = new InjectedValue<JBossContextXATerminator>();
 
     private final InjectedValue<JcaSubsystemConfiguration> jcaConfig = new InjectedValue<JcaSubsystemConfiguration>();
 
@@ -109,7 +109,7 @@ public final class BootStrapContextService implements Service<CloneableBootstrap
         return txManager;
     }
 
-    public Injector<JBossXATerminator> getXaTerminatorInjector() {
+    public Injector<JBossContextXATerminator> getXaTerminatorInjector() {
         return xaTerminator;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
@@ -28,6 +28,7 @@ import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 import org.jboss.jca.core.tx.jbossts.TransactionIntegrationImpl;
 import org.jboss.msc.inject.Injector;
@@ -36,7 +37,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.tm.JBossXATerminator;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.jboss.tm.usertx.UserTransactionRegistry;
 
@@ -54,7 +54,7 @@ public final class TransactionIntegrationService implements Service<TransactionI
 
     private final InjectedValue<UserTransactionRegistry> utr = new InjectedValue<UserTransactionRegistry>();
 
-    private final InjectedValue<JBossXATerminator> terminator = new InjectedValue<JBossXATerminator>();
+    private final InjectedValue<JBossContextXATerminator> terminator = new InjectedValue<JBossContextXATerminator>();
 
     private final InjectedValue<XAResourceRecoveryRegistry> rr = new InjectedValue<XAResourceRecoveryRegistry>();
 
@@ -92,7 +92,7 @@ public final class TransactionIntegrationService implements Service<TransactionI
         return utr;
     }
 
-    public Injector<JBossXATerminator> getTerminatorInjector() {
+    public Injector<JBossContextXATerminator> getTerminatorInjector() {
         return terminator;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/DistributedWorkManagerService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/DistributedWorkManagerService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executor;
 import org.jboss.as.connector.security.ElytronSecurityIntegration;
 import org.jboss.as.connector.services.workmanager.transport.ForkChannelTransport;
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.security.picketbox.PicketBoxSecurityIntegration;
 import org.jboss.jca.core.tx.jbossts.XATerminatorImpl;
 import org.jboss.jca.core.workmanager.WorkManagerCoordinator;
@@ -40,7 +41,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.threads.BlockingExecutor;
-import org.jboss.tm.JBossXATerminator;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 
 /**
@@ -57,7 +57,7 @@ public final class DistributedWorkManagerService implements Service<NamedDistrib
 
     private final InjectedValue<Executor> executorLong = new InjectedValue<Executor>();
 
-    private final InjectedValue<JBossXATerminator> xaTerminator = new InjectedValue<JBossXATerminator>();
+    private final InjectedValue<JBossContextXATerminator> xaTerminator = new InjectedValue<JBossContextXATerminator>();
 
     private final InjectedValue<ChannelFactory> jGroupsChannelFactory = new InjectedValue<ChannelFactory>();
 
@@ -150,7 +150,7 @@ public final class DistributedWorkManagerService implements Service<NamedDistrib
         return executorLong;
     }
 
-    public Injector<JBossXATerminator> getXaTerminatorInjector() {
+    public Injector<JBossContextXATerminator> getXaTerminatorInjector() {
         return xaTerminator;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/WorkManagerService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/WorkManagerService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executor;
 
 import org.jboss.as.connector.security.ElytronSecurityIntegration;
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.security.picketbox.PicketBoxSecurityIntegration;
 import org.jboss.jca.core.tx.jbossts.XATerminatorImpl;
 import org.jboss.jca.core.workmanager.WorkManagerCoordinator;
@@ -39,7 +40,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.threads.BlockingExecutor;
-import org.jboss.tm.JBossXATerminator;
 
 /**
  * A WorkManager Service.
@@ -55,7 +55,7 @@ public final class WorkManagerService implements Service<NamedWorkManager> {
 
     private final InjectedValue<Executor> executorLong = new InjectedValue<Executor>();
 
-    private final InjectedValue<JBossXATerminator> xaTerminator = new InjectedValue<JBossXATerminator>();
+    private final InjectedValue<JBossContextXATerminator> xaTerminator = new InjectedValue<JBossContextXATerminator>();
 
     /**
      * create an instance
@@ -132,7 +132,7 @@ public final class WorkManagerService implements Service<NamedWorkManager> {
         return executorLong;
     }
 
-    public Injector<JBossXATerminator> getXaTerminatorInjector() {
+    public Injector<JBossContextXATerminator> getXaTerminatorInjector() {
         return xaTerminator;
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
@@ -29,6 +29,7 @@ import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.core.api.bootstrap.CloneableBootstrapContext;
@@ -36,7 +37,6 @@ import org.jboss.jca.core.api.workmanager.WorkManager;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.tm.JBossXATerminator;
 
 /**
  * @author <a href="jesper.pedersen@jboss.org">Jesper Pedersen</a>
@@ -73,7 +73,7 @@ public class BootstrapContextAdd extends AbstractAddStepHandler {
                 serviceTarget
                         .addService(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append(name), bootCtxService)
                         .addDependency(ServiceBuilder.DependencyType.REQUIRED, ConnectorServices.WORKMANAGER_SERVICE.append(workmanager), WorkManager.class, bootCtxService.getWorkManagerValueInjector())
-                        .addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, bootCtxService.getXaTerminatorInjector())
+                        .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, bootCtxService.getXaTerminatorInjector())
                         .addDependency(TxnServices.JBOSS_TXN_ARJUNA_TRANSACTION_MANAGER, com.arjuna.ats.jbossatx.jta.TransactionManagerService.class, bootCtxService.getTxManagerInjector())
                         .addDependency(ConnectorServices.CONNECTOR_CONFIG_SERVICE, JcaSubsystemConfiguration.class, bootCtxService.getJcaConfigInjector())
                         .setInitialMode(ServiceController.Mode.ACTIVE)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/DistributedWorkManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/DistributedWorkManagerAdd.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.threads.ThreadsServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.core.api.workmanager.DistributedWorkManager;
@@ -55,7 +56,6 @@ import org.jboss.jca.core.workmanager.selector.PingTime;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.tm.JBossXATerminator;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.JGroupsDefaultRequirement;
 
@@ -153,7 +153,7 @@ public class DistributedWorkManagerAdd extends AbstractAddStepHandler {
         builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name), Executor.class, wmService.getExecutorLongInjector());
         builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name), Executor.class, wmService.getExecutorShortInjector());
 
-        builder.addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, wmService.getXaTerminatorInjector())
+        builder.addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, wmService.getXaTerminatorInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
         WorkManagerStatisticsService wmStatsService = new WorkManagerStatisticsService(context.getResourceRegistrationForUpdate(), name, true);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -35,12 +35,12 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.tm.JBossXATerminator;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 
 /**
@@ -77,7 +77,7 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, tiService.getTmInjector())
                 .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, tiService.getTsrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, org.jboss.tm.usertx.UserTransactionRegistry.class, tiService.getUtrInjector())
-                .addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, tiService.getTerminatorInjector())
+                .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, tiService.getTerminatorInjector())
                 .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, XAResourceRecoveryRegistry.class, tiService.getRrInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/WorkManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/WorkManagerAdd.java
@@ -37,13 +37,13 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.threads.ThreadsServices;
+import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.core.api.workmanager.WorkManager;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.tm.JBossXATerminator;
 
 /**
  * @author <a href="jesper.pedersen@jboss.org">Jesper Pedersen</a>
@@ -79,7 +79,7 @@ public class WorkManagerAdd extends AbstractAddStepHandler {
         builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name), Executor.class, wmService.getExecutorLongInjector());
         builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name), Executor.class, wmService.getExecutorShortInjector());
 
-        builder.addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, wmService.getXaTerminatorInjector())
+        builder.addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, wmService.getXaTerminatorInjector())
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install();
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/suspend/EJBSuspendHandlerService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/suspend/EJBSuspendHandlerService.java
@@ -273,7 +273,7 @@ public class EJBSuspendHandlerService implements Service<EJBSuspendHandlerServic
     /**
      * Notifies handler that a new transaction has been created.
      */
-    @Override public void transactionCreated(AbstractTransaction transaction) {
+    @Override public void transactionCreated(AbstractTransaction transaction, CreatedBy createdBy) {
         activeTransactionCountUpdater.incrementAndGet(this);
         try {
             transaction.registerSynchronization(this);

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -61,6 +61,7 @@
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.jts.integration"/>
+        <module name="org.wildfly.transaction.client"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.modules"/>

--- a/pom.xml
+++ b/pom.xml
@@ -162,9 +162,9 @@
         <version.org.jboss.genericjms>2.0.0.Alpha2</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.4.2.Final</version.org.jboss.ironjacamar>
-        <version.org.jboss.jboss-transaction-spi>7.5.1.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.5.2.Final-SNAPSHOT</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Final</version.org.jboss.metadata>
-        <version.org.jboss.narayana>5.5.3.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.5.4.Final-SNAPSHOT</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.6.CR2</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.0.7.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
@@ -222,7 +222,7 @@
         <version.org.wildfly.http-client>1.0.0.Alpha3</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.0.Beta11</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-subsystem>1.0.0.Beta11</version.org.wildfly.security.elytron-subsystem>
-        <version.org.wildfly.transaction.client>1.0.0.Beta18</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>1.0.0.Beta19-SNAPSHOT</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.17</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowMdb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowMdb.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import org.jboss.as.test.integration.transactions.TestXAResource;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.ejb3.annotation.ResourceAdapter;
+import org.jboss.logging.Logger;
+
+/**
+ * MDB bound to resource adapter deployed in test.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+// @MessageDriven is defined in ejb-jar.xml
+@ResourceAdapter(TransactionInflowMdb.RESOURCE_ADAPTER_NAME + ".rar")
+public class TransactionInflowMdb implements MessageListener {
+    private static final Logger log = Logger.getLogger(TransactionInflowMdb.class);
+
+    public static final String RESOURCE_ADAPTER_NAME = "inflow-txn-ra";
+
+    @EJB
+    private TransactionCheckerSingleton checker;
+
+    @Resource(lookup = "java:/TransactionManager")
+    private TransactionManager transactionManager;
+
+    public void onMessage(Message msg) {
+        String text = getText(msg);
+        log.tracef("%s.onMessage with message: %s[%s]", this.getClass().getSimpleName(), text, msg);
+
+        try {
+            Transaction tx = transactionManager.getTransaction();
+            if (tx == null || tx.getStatus() != Status.STATUS_ACTIVE) {
+                log.error("Test method called without an active transaction!");
+                throw new IllegalStateException("Test method called without an active transaction!");
+            }
+        } catch (SystemException e) {
+            log.error("Cannot get the current transaction!", e);
+            throw new RuntimeException("Cannot get the current transaction!", e);
+        }
+
+        enlistXAResource();
+        enlistXAResource();
+
+        checker.addMessage(text);
+        log.tracef("Message '%s' processed", text);
+    }
+
+    protected void enlistXAResource() {
+        log.trace(this.getClass().getSimpleName() + ".enlistXAResource()");
+        try {
+            TestXAResource testXAResource = new TestXAResource(checker);
+            transactionManager.getTransaction().enlistResource(testXAResource);
+        } catch (Exception e) {
+            log.error("Could not enlist TestXAResourceUnique", e);
+            throw new IllegalStateException("Could not enlist TestXAResourceUnique", e);
+        }
+    }
+
+    private String getText(Message msg) {
+        try {
+            return ((TransactionInflowTextMessage) msg).getText();
+        } catch (JMSException e) {
+            throw new RuntimeException("Can't get text from message: " + msg, e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowRaSpec.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowRaSpec.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+
+/**
+ * Mock spec rar class. Referred in ra.xml.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionInflowRaSpec implements ActivationSpec {
+
+    private volatile ResourceAdapter resourceAdapter;
+    private volatile String action;
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return resourceAdapter;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter ra) throws ResourceException {
+        this.resourceAdapter = ra;
+    }
+
+    @Override
+    public void validate() throws InvalidPropertyException {
+        // everything ok
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s <rar = %s, action = %s> [%s]",
+            TransactionInflowRaSpec.class.getName(), resourceAdapter, action, super.toString());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowResourceAdapter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowResourceAdapter.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.TransactionContext;
+import javax.resource.spi.work.WorkException;
+import javax.resource.spi.work.WorkManager;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.logging.Logger;
+
+/**
+ * Implementation of resource adapter for transaction inflow testing.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionInflowResourceAdapter implements ResourceAdapter {
+    private static final Logger log = Logger.getLogger(TransactionInflowResourceAdapter.class);
+
+    private BootstrapContext bootstrapContext;
+
+    static final String MSG = "inflow RAR test message";
+    static final String ACTION_COMMIT = "commit";
+    static final String ACTION_ROLLBACK = "rollback";
+
+    public void start(BootstrapContext ctx) throws ResourceAdapterInternalException {
+        log.tracef("Starting '%s' with context '%s'", TransactionInflowResourceAdapter.class.getSimpleName(), ctx);
+        this.bootstrapContext = ctx;
+    }
+
+    public void stop() {
+        log.tracef("Stopping (do nothing) '%s'", TransactionInflowResourceAdapter.class.getSimpleName());
+    }
+
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) throws ResourceException {
+        Xid xid = TransactionInflowXid.getUniqueXid(42);
+        TransactionInflowWork work = new TransactionInflowWork(endpointFactory, MSG);
+        TransactionContext txnCtx = new TransactionContext();
+        txnCtx.setXid(xid);
+
+        TransactionInflowWorkListener workListener = new TransactionInflowWorkListener();
+
+        try {
+            bootstrapContext.getWorkManager().startWork(work, WorkManager.IMMEDIATE, txnCtx, workListener);
+        } catch (WorkException e) {
+            throw new IllegalStateException("Can't start work " + work + " with txn " + txnCtx);
+        }
+
+        // start Work blocks until the execution starts but not until its completion
+        int timeout = TimeoutUtil.adjust(10_000); // timeout 10 seconds
+        long start = System.currentTimeMillis();
+        while(!workListener.isCompleted() && (System.currentTimeMillis() - start < timeout)) {
+            Thread.yield(); // active waiting
+        }
+        if(!workListener.isCompleted()) throw new IllegalStateException("Work " + work + " of xid " + xid + " does not finish.");
+
+        try {
+            bootstrapContext.getXATerminator().prepare(xid);
+
+            // depends on value in spec we commit or roll-back
+            TransactionInflowRaSpec activationSpec = (TransactionInflowRaSpec) spec;
+            if(activationSpec.getAction().equals(ACTION_COMMIT)) {
+                bootstrapContext.getXATerminator().commit(xid, false);
+            } else if(activationSpec.getAction().equals(ACTION_ROLLBACK)) {
+                bootstrapContext.getXATerminator().rollback(xid);
+            } else {
+                new IllegalStateException("Spec '" + activationSpec + "' defines unknown action");
+            }
+        } catch (XAException xae) {
+            throw new IllegalStateException("Can't process prepare/commit/rollback calls for xid: " + xid, xae);
+        }
+    }
+
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) {
+        // nothing to do
+    }
+
+    public XAResource[] getXAResources(ActivationSpec[] specs) throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((bootstrapContext == null) ? 0 : bootstrapContext.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TransactionInflowResourceAdapter other = (TransactionInflowResourceAdapter) obj;
+        if (bootstrapContext == null) {
+            if (other.bootstrapContext != null)
+                return false;
+        } else if (!bootstrapContext.equals(other.bootstrapContext))
+            return false;
+        return true;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTestCase.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.util.Hashtable;
+import java.util.PropertyPermission;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.transactions.TestXAResource;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingletonRemote;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Testcase running jca inflow transaction from deployed RAR.
+ * Two mock XA resources are enlisted inside of MDB to proceed 2PC.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TransactionInflowTestCase {
+
+    private static final String EJB_MODULE_NAME = "inflow-ejb-";
+    private static final String COMMIT = TransactionInflowResourceAdapter.ACTION_COMMIT;
+    private static final String ROLLBACK = TransactionInflowResourceAdapter.ACTION_ROLLBACK;
+
+    @ArquillianResource
+    public Deployer deployer;
+
+    @Deployment(name = TransactionInflowMdb.RESOURCE_ADAPTER_NAME, order = 1)
+    public static ResourceAdapterArchive getResourceAdapterDeployment() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "inflow-txn-inside.jar")
+            .addClasses(TransactionInflowResourceAdapter.class)
+            .addClasses(TransactionInflowXid.class, TransactionInflowWork.class, TransactionInflowRaSpec.class,
+                TransactionInflowTextMessage.class, TransactionInflowWorkListener.class, TimeoutUtil.class);
+
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class,
+                TransactionInflowMdb.RESOURCE_ADAPTER_NAME + ".rar")
+            .addAsResource(TransactionInflowTestCase.class.getPackage(), "ra.xml", "META-INF/ra.xml")
+            .addAsManifestResource(createPermissionsXmlAsset(
+                    new RuntimePermission("accessDeclaredMembers"),
+                    new RuntimePermission("getClassLoader"),
+                    new RuntimePermission("defineClassInPackage.org.jboss.as.test.integration.transaction.inflow"),
+                    new PropertyPermission("ts.timeout.factor", "read"))
+                    , "jboss-permissions.xml")
+            .addAsLibrary(jar);
+
+        System.out.println(rar.toString(true));
+        return rar;
+    }
+
+    /**
+     * Based on action parameter particular ejb-jar*.xml file is added to archive.
+     * The ejb-jar.xml defines RAR spec config property.
+     */
+    public static JavaArchive getEjbDeployment(String action) {
+        return ShrinkWrap.create(JavaArchive.class, EJB_MODULE_NAME + action + ".jar")
+            .addClasses(TransactionInflowMdb.class)
+            .addClasses(TransactionCheckerSingleton.class, TransactionCheckerSingletonRemote.class)
+            .addClasses(TestXAResource.class)
+            .addAsResource(TransactionInflowTestCase.class.getPackage(), "ejb-jar-" + action + ".xml", "META-INF/ejb-jar.xml")
+            // module dependency on rar is added because we want to share class of TransactionInflowTextMessage
+            // and arquillian packs this testcase class to container here and it needs to see rar classes as well
+            .addAsManifestResource(new StringAsset("Dependencies: deployment."
+                + TransactionInflowMdb.RESOURCE_ADAPTER_NAME+ ".rar\n"), "MANIFEST.MF");
+    }
+
+    @Deployment(name = EJB_MODULE_NAME + COMMIT, managed = false, testable = false)
+    public static JavaArchive getCommitDeployment() {
+        return getEjbDeployment(COMMIT);
+    }
+
+    @Deployment(name = EJB_MODULE_NAME + ROLLBACK, managed = false, testable = false)
+    public static JavaArchive getRollbackDeployment() {
+        return getEjbDeployment(ROLLBACK);
+    }
+
+    @After
+    public void cleanUp() {
+        deployer.undeploy(EJB_MODULE_NAME + COMMIT);
+        deployer.undeploy(EJB_MODULE_NAME + ROLLBACK);
+    }
+
+    @Test
+    public void inflowTransactionCommit() throws NamingException {
+        deployer.deploy(EJB_MODULE_NAME + COMMIT);
+
+        TransactionCheckerSingletonRemote checker = getSingletonChecker(EJB_MODULE_NAME + COMMIT);
+
+        try {
+            Assert.assertEquals("Expecting one message was passed from RAR to MDB", 1, checker.getMessages().size());
+            Assert.assertEquals("Expecting message with the content was passed from RAR to MDB",
+                    TransactionInflowResourceAdapter.MSG, checker.getMessages().iterator().next());
+            Assert.assertEquals("Two XAResources were enlisted thus expected to be prepared", 2, checker.getPrepared());
+            Assert.assertEquals("Two XAResources are expected to be committed", 2, checker.getCommitted());
+            Assert.assertEquals("Two XAResources were were committed thus not rolled-back", 0, checker.getRolledback());
+        } finally {
+            checker.resetAll();
+        }
+    }
+
+    @Test
+    public void inflowTransactionRollback() throws NamingException {
+        deployer.deploy(EJB_MODULE_NAME + ROLLBACK);
+
+        TransactionCheckerSingletonRemote checker = getSingletonChecker(EJB_MODULE_NAME + ROLLBACK);
+
+        try {
+            Assert.assertEquals("Expecting one message was passed from RAR to MDB", 1, checker.getMessages().size());
+            Assert.assertEquals("Expecting message with the content was passed from RAR to MDB",
+                    TransactionInflowResourceAdapter.MSG, checker.getMessages().iterator().next());
+            Assert.assertEquals("Two XAResources were enlisted thus expected to be prepared", 2, checker.getPrepared());
+            Assert.assertEquals("Two XAResources are expected to be rolled-back", 2, checker.getRolledback());
+            Assert.assertEquals("Two XAResources were were rolled-bck thus not committed", 0, checker.getCommitted());
+        } finally {
+            checker.resetAll();
+        }
+    }
+
+
+    private TransactionCheckerSingletonRemote getSingletonChecker(String moduleName) throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        String ejbLookupString = Util.createRemoteEjbJndiContext("", moduleName, "",
+                TransactionCheckerSingleton.class.getSimpleName(), TransactionCheckerSingletonRemote.class.getName(), false);
+        TransactionCheckerSingletonRemote checker = (TransactionCheckerSingletonRemote) context.lookup(ejbLookupString);
+        return checker;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTextMessage.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowTextMessage.java
@@ -1,0 +1,252 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import java.util.Enumeration;
+import java.util.Random;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+
+/**
+ * Test message used for testing in jca inflow transaction rar.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionInflowTextMessage implements javax.jms.TextMessage {
+    private int messageId = new Random().nextInt();
+    private String text;
+
+    public TransactionInflowTextMessage(String text) {
+        this.text = text;
+    }
+
+    public String getJMSMessageID() throws JMSException {
+        return messageId + "-" + text;
+    }
+
+    public void setText(String string) throws JMSException {
+        this.text = string;
+    }
+
+    public String getText() throws JMSException {
+        return this.text;
+    }
+
+    public String getTextCleaned() {
+        return this.text;
+    }
+
+    public void setJMSMessageID(String id) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public long getJMSTimestamp() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSTimestamp(long timestamp) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public byte[] getJMSCorrelationIDAsBytes() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSCorrelationID(String correlationID) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getJMSCorrelationID() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Destination getJMSReplyTo() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSReplyTo(Destination replyTo) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Destination getJMSDestination() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSDestination(Destination destination) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getJMSDeliveryMode() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSDeliveryMode(int deliveryMode) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean getJMSRedelivered() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSRedelivered(boolean redelivered) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getJMSType() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSType(String type) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public long getJMSExpiration() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSExpiration(long expiration) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public long getJMSDeliveryTime() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSDeliveryTime(long deliveryTime) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getJMSPriority() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setJMSPriority(int priority) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void clearProperties() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean propertyExists(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean getBooleanProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public byte getByteProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public short getShortProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getIntProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public long getLongProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public float getFloatProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public double getDoubleProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getStringProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Object getObjectProperty(String name) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("rawtypes")
+    public Enumeration getPropertyNames() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setBooleanProperty(String name, boolean value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setByteProperty(String name, byte value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setShortProperty(String name, short value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setIntProperty(String name, int value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setLongProperty(String name, long value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setFloatProperty(String name, float value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setDoubleProperty(String name, double value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setStringProperty(String name, String value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setObjectProperty(String name, Object value) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void acknowledge() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void clearBody() throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public <T> T getBody(Class<T> c) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean isBodyAssignableTo(@SuppressWarnings("rawtypes") Class c) throws JMSException {
+        throw new UnsupportedOperationException();
+    }
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWork.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWork.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import javax.jms.MessageListener;
+import javax.resource.spi.UnavailableException;
+import javax.resource.spi.endpoint.MessageEndpoint;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.Work;
+import org.jboss.logging.Logger;
+
+/**
+ * JCA work executing onMessage method with text message payload.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionInflowWork implements Work {
+    private static final Logger log = Logger.getLogger(TransactionInflowWork.class);
+
+    private MessageEndpointFactory messageFactory;
+    private String msg;
+
+    TransactionInflowWork(MessageEndpointFactory messageFactory, String msg) {
+        this.messageFactory = messageFactory;
+        this.msg = msg;
+    }
+
+    public void run() {
+        MessageEndpoint messageEndpoint;
+        try {
+            messageEndpoint = messageFactory.createEndpoint(null);
+            if (messageEndpoint instanceof MessageListener){
+                log.tracef("Calling on message on endpoint '%s' with data message '%s'", messageEndpoint, msg);
+                TransactionInflowTextMessage textMessage = new TransactionInflowTextMessage(msg);
+                ((MessageListener) messageEndpoint).onMessage(textMessage);
+            } else {
+                throw new IllegalStateException("Not supported message endpoint: " + messageEndpoint);
+            }
+        } catch (UnavailableException ue) {
+            String msg = String.format("Not capable to create message factory '%s' endpoint", messageFactory);
+            throw new IllegalStateException(msg, ue);
+        }
+    }
+
+    public void release() {
+        // nothing to release
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWorkListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowWorkListener.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.resource.spi.work.WorkEvent;
+import javax.resource.spi.work.WorkListener;
+
+/**
+ * Simple listener to monitor if work was done already.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionInflowWorkListener implements WorkListener {
+    private AtomicBoolean isAccepted = new AtomicBoolean(false);
+    private AtomicBoolean isRejected = new AtomicBoolean(false);
+    private AtomicBoolean isStarted = new AtomicBoolean(false);
+    private AtomicBoolean isCompleted = new AtomicBoolean(false);
+
+    @Override
+    public void workAccepted(WorkEvent e) {
+        isAccepted.set(true);
+    }
+
+    @Override
+    public void workRejected(WorkEvent e) {
+        isRejected.set(true);
+    }
+
+    @Override
+    public void workStarted(WorkEvent e) {
+        isStarted.set(true);
+    }
+
+    @Override
+    public void workCompleted(WorkEvent e) {
+        isCompleted.set(true);
+    }
+
+    boolean isAccepted() {
+        return isAccepted.get();
+    }
+
+    boolean isRejected() {
+        return isRejected.get();
+    }
+
+    boolean isStarted() {
+        return isStarted.get();
+    }
+
+    boolean isCompleted() {
+        return isCompleted.get();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowXid.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/TransactionInflowXid.java
@@ -1,0 +1,180 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transaction.inflow;
+
+import java.net.Inet4Address;
+import java.util.Arrays;
+import java.util.Random;
+
+import javax.transaction.xa.Xid;
+
+/**
+ * Test {@link Xid} implementation.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+class TransactionInflowXid implements Xid {
+    private static byte[] localIP = null;
+    private static int txnUniqueID = 0;
+
+    public int formatId;
+    public byte[] gtrid;
+    public byte[] bqual;
+
+    public byte[] getGlobalTransactionId() {
+        return gtrid;
+    }
+
+    public byte[] getBranchQualifier() {
+        return bqual;
+    }
+
+    public int getFormatId() {
+        return formatId;
+    }
+
+    private TransactionInflowXid(int formatId, byte[] gtrid, byte[] bqual) {
+        this.formatId = formatId;
+        this.gtrid = gtrid;
+        this.bqual = bqual;
+    }
+
+    public String toString() {
+        int hexVal;
+        StringBuffer sb = new StringBuffer(512);
+        sb.append("formatId=" + formatId);
+        sb.append(" gtrid(" + gtrid.length + ")={0x");
+        for (int i = 0; i < gtrid.length; i++) {
+            hexVal = gtrid[i] & 0xFF;
+            if (hexVal < 0x10)
+                sb.append("0" + Integer.toHexString(gtrid[i] & 0xFF));
+            else
+                sb.append(Integer.toHexString(gtrid[i] & 0xFF));
+        }
+        sb.append("} bqual(" + bqual.length + ")={0x");
+        for (int i = 0; i < bqual.length; i++) {
+            hexVal = bqual[i] & 0xFF;
+            if (hexVal < 0x10)
+                sb.append("0" + Integer.toHexString(bqual[i] & 0xFF));
+            else
+                sb.append(Integer.toHexString(bqual[i] & 0xFF));
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Returns a globally unique transaction id.
+     *
+     * Xid "number" is based on provided tid argument,
+     * inet local host address, static counter of generated ids
+     * and a random int number.
+     *
+     * Xid format is static value 4660.
+     */
+    static Xid getUniqueXid(int tid) {
+        Random rnd = new Random(System.currentTimeMillis());
+        txnUniqueID++;
+        int txnUID = txnUniqueID;
+        int tidID = tid;
+        int randID = rnd.nextInt();
+
+        return getXid(txnUID, tidID, randID);
+    }
+
+    /**
+     * Returns a transaction id which is based on tid
+     * calculated the same all the time.
+     *
+     * Variables which are part of the calculation
+     * are inet local host address.
+     *
+     * Xid format is static value 4660.
+     */
+    static Xid getStableXid(int tid) {
+        int txnUID = 0;
+        int tidID = tid;
+        int answerToEverythingID = 42;
+
+        return getXid(txnUID, tidID, answerToEverythingID);
+    }
+
+    private static Xid getXid(int txnUID, int tidID, int quaziRandID) {
+        byte[] gtrid = new byte[64];
+        byte[] bqual = new byte[64];
+
+        if (null == localIP) {
+            try {
+                localIP = Inet4Address.getLocalHost().getAddress();
+            } catch (Exception ex) {
+                localIP = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            }
+        }
+
+        // global transaction qualifier
+        System.arraycopy(localIP, 0, gtrid, 0, 4);
+        // branch transaction qualifier
+        System.arraycopy(localIP, 0, bqual, 0, 4);
+
+        for (int i = 0; i <= 3; i++) {
+            gtrid[i + 4] = (byte) (txnUID % 0x100);
+            bqual[i + 4] = (byte) (txnUID % 0x100);
+            txnUID >>= 8;
+            gtrid[i + 8] = (byte) (tidID % 0x100);
+            bqual[i + 8] = (byte) (tidID % 0x100);
+            tidID >>= 8;
+            gtrid[i + 12] = (byte) (quaziRandID % 0x100);
+            bqual[i + 12] = (byte) (quaziRandID % 0x100);
+            quaziRandID >>= 8;
+        }
+        return new TransactionInflowXid(0x1234, gtrid, bqual);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(bqual);
+        result = prime * result + formatId;
+        result = prime * result + Arrays.hashCode(gtrid);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TransactionInflowXid other = (TransactionInflowXid) obj;
+        if (!Arrays.equals(bqual, other.bqual))
+            return false;
+        if (formatId != other.formatId)
+            return false;
+        if (!Arrays.equals(gtrid, other.gtrid))
+            return false;
+        return true;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ejb-jar-commit.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ejb-jar-commit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+     version="3.2"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd">
+  <enterprise-beans>
+    <message-driven>
+      <ejb-name>TransactionInflowMessageDrivenBeanCommit</ejb-name>
+      <ejb-class>org.jboss.as.test.integration.transaction.inflow.TransactionInflowMdb</ejb-class>
+      <messaging-type>javax.jms.MessageListener</messaging-type>
+      <transaction-type>Container</transaction-type>
+      <activation-config>
+        <activation-config-property>
+          <activation-config-property-name>action</activation-config-property-name>
+          <activation-config-property-value>commit</activation-config-property-value>
+        </activation-config-property>
+      </activation-config>
+    </message-driven>
+  </enterprise-beans>
+</ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ejb-jar-rollback.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ejb-jar-rollback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+     version="3.2"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd">
+  <enterprise-beans>
+    <message-driven>
+      <ejb-name>TransactionInflowMessageDrivenBeanCommit</ejb-name>
+      <ejb-class>org.jboss.as.test.integration.transaction.inflow.TransactionInflowMdb</ejb-class>
+      <messaging-type>javax.jms.MessageListener</messaging-type>
+      <transaction-type>Container</transaction-type>
+      <activation-config>
+        <activation-config-property>
+          <activation-config-property-name>action</activation-config-property-name>
+          <activation-config-property-value>rollback</activation-config-property-value>
+        </activation-config-property>
+      </activation-config>
+    </message-driven>
+  </enterprise-beans>
+</ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ra.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/inflow/ra.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://java.sun.com/xml/ns/j2ee" version="1.5">
+  <display-name>Inflow Transaction Test Resource Adapter</display-name>
+  <vendor-name>WildFly</vendor-name>
+  <eis-type>Test RA</eis-type>
+  <resourceadapter-version>1.0</resourceadapter-version>
+  <resourceadapter>
+    <resourceadapter-class>org.jboss.as.test.integration.transaction.inflow.TransactionInflowResourceAdapter</resourceadapter-class>
+    <inbound-resourceadapter>
+      <messageadapter>
+        <messagelistener>
+          <messagelistener-type>javax.jms.MessageListener</messagelistener-type>
+          <activationspec>
+            <activationspec-class>org.jboss.as.test.integration.transaction.inflow.TransactionInflowRaSpec</activationspec-class>
+          </activationspec>
+        </messagelistener>
+      </messageadapter>
+    </inbound-resourceadapter>
+    <config-property>
+      <config-property-name>action</config-property-name>
+      <config-property-type>java.lang.String</config-property-type>
+    </config-property>
+  </resourceadapter>
+</connector>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TestXAResource.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TestXAResource.java
@@ -25,7 +25,6 @@ package org.jboss.as.test.integration.transactions;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -75,6 +74,7 @@ public class TestXAResource implements XAResource {
     @Override
     public int prepare(Xid xid) throws XAException {
         log.tracef("prepare xid: [%s]", xid);
+        checker.addPrepare();
         return prepareReturnValue;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TransactionCheckerSingleton.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TransactionCheckerSingleton.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.test.integration.transactions;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import javax.annotation.ManagedBean;
 import javax.ejb.LocalBean;
 import javax.ejb.Remote;
@@ -37,9 +40,10 @@ import javax.ejb.Singleton;
 @Remote
 @ManagedBean
 public class TransactionCheckerSingleton implements TransactionCheckerSingletonRemote {
-    private int committed, rolledback;
+    private int committed, prepared, rolledback;
     private int  synchronizedBegin, synchronizedBefore, synchronizedAfter,
         synchronizedAfterCommitted, synchronizedAfterRolledBack;
+    private Collection<String> messages = new ArrayList<>();
 
     @Override
     public int getCommitted() {
@@ -49,6 +53,16 @@ public class TransactionCheckerSingleton implements TransactionCheckerSingletonR
     @Override
     public void addCommit() {
         committed++;
+    }
+
+    @Override
+    public int getPrepared() {
+        return prepared;
+    }
+
+    @Override
+    public void addPrepare() {
+        prepared++;
     }
 
     @Override
@@ -102,6 +116,11 @@ public class TransactionCheckerSingleton implements TransactionCheckerSingletonR
     }
 
     @Override
+    public void resetPrepared() {
+        prepared = 0;
+    }
+
+    @Override
     public void resetRolledback() {
         rolledback = 0;
     }
@@ -149,11 +168,28 @@ public class TransactionCheckerSingleton implements TransactionCheckerSingletonR
     }
 
     @Override
+    public void addMessage(String msg) {
+        messages.add(msg);
+    }
+
+    @Override
+    public Collection<String> getMessages() {
+        return messages;
+    }
+
+    @Override
+    public void resetMessages() {
+        messages.clear();
+    }
+
+    @Override
     public void resetAll() {
         resetCommitted();
+        resetPrepared();
         resetRolledback();
         resetSynchronizedAfter();
         resetSynchronizedBefore();
         resetSynchronizedBegin();
+        resetMessages();
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TransactionCheckerSingletonRemote.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TransactionCheckerSingletonRemote.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.transactions;
 
+import java.util.Collection;
+
 /**
  * Interface used as remote point to {@link TransactionCheckerSingleton} class
  * that is used for verification of test workflow.
@@ -32,6 +34,9 @@ public interface TransactionCheckerSingletonRemote {
     int getCommitted();
     void addCommit();
     void resetCommitted();
+    int getPrepared();
+    void addPrepare();
+    void resetPrepared();
     int getRolledback();
     void addRollback();
     void resetRolledback();
@@ -49,5 +54,8 @@ public interface TransactionCheckerSingletonRemote {
     int countSynchronizedBegin();
     void setSynchronizedBegin();
     void resetSynchronizedBegin();
+    void addMessage(String msg);
+    Collection<String> getMessages();
+    void resetMessages();
     void resetAll();
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -44,10 +44,6 @@ public final class TxTestUtil {
         // no instance here
     }
 
-    public static TestXAResource enlistTestXAResource(Transaction txn, TransactionCheckerSingletonRemote checker) {
-        return enlistTestXAResource(txn, checker);
-    }
-
     public static TestXAResource enlistTestXAResource(Transaction txn, TransactionCheckerSingleton checker) {
         TestXAResource xaResource = new TestXAResource(checker);
         try {

--- a/transactions/src/main/java/org/jboss/as/txn/integration/JBossContextXATerminator.java
+++ b/transactions/src/main/java/org/jboss/as/txn/integration/JBossContextXATerminator.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.integration;
+
+import javax.resource.spi.XATerminator;
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkCompletedException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.SystemException;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
+
+import org.jboss.as.txn.logging.TransactionLogger;
+import org.jboss.tm.JBossXATerminator;
+import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ImportResult;
+import org.wildfly.transaction.client.LocalTransaction;
+import org.wildfly.transaction.client.LocalTransactionContext;
+
+import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
+
+public class JBossContextXATerminator implements JBossXATerminator {
+
+    private final LocalTransactionContext localTransactionContext;
+    private final XATerminator contextXATerminator;
+    private final JBossXATerminator jbossXATerminator;
+
+    public JBossContextXATerminator(LocalTransactionContext transactionContext, JBossXATerminator jbossXATerminator) {
+        this.localTransactionContext = transactionContext;
+        this.contextXATerminator = transactionContext.getXATerminator();
+        this.jbossXATerminator = jbossXATerminator;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        contextXATerminator.commit(xid, onePhase);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        contextXATerminator.forget(xid);
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        return contextXATerminator.prepare(xid);
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+        return contextXATerminator.recover(flag);
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        contextXATerminator.rollback(xid);
+    }
+
+
+    /**
+     * <p>
+     * Interception of register work call to get transaction being imported to wildfly transacton client.
+     * <p>
+     * For importing a transaction Wildfly transaction client eventually calls {@link SubordinationManager}
+     * as Narayana {@link XATerminator}s do. This wrapping then let wildfly transacton client to register the transaction
+     * for itself, wildfly transacton client then import transaction to Narayana too and finally this method
+     * uses Narayana's {@link XATerminator} to register all {@link Work}s binding.<br>
+     * Narayana's {@link XATerminator} tries to import transaction too but as transaction is already
+     * imported it just gets instance of transaction already imported via call of wildfly transacton client.
+     */
+    @Override
+    public void registerWork(Work work, Xid xid, long timeout) throws WorkCompletedException {
+        try {
+            // jca provides timeout in milliseconds, SubordinationManager expects seconds
+            int timeout_seconds = (int) timeout/1000;
+            // unlimited timeout for jca means -1 which fails in wfly client
+            if(timeout_seconds <= 0) timeout_seconds = ContextTransactionManager.getGlobalDefaultTransactionTimeout();
+            localTransactionContext.findOrImportTransaction(xid, timeout_seconds);
+        } catch (XAException xae) {
+            throw TransactionLogger.ROOT_LOGGER.cannotFindOrImportInflowTransaction(xid, work, xae);
+        }
+
+        jbossXATerminator.registerWork(work, xid, timeout);
+    }
+
+    /**
+     * <p>
+     * Start work gets imported transaction and assign it to current thread.
+     * <p>
+     * This method mimics behavior of Narayana's {@link JBossXATerminator}.
+     */
+    @Override
+    public void startWork(Work work, Xid xid) throws WorkCompletedException {
+        LocalTransaction transaction = null;
+        try {
+            ImportResult<LocalTransaction> transactionImportResult = localTransactionContext.findOrImportTransaction(xid, 0);
+            transaction = transactionImportResult.getTransaction();
+            ContextTransactionManager.getInstance().resume(transaction);
+        } catch (XAException xae) {
+            throw TransactionLogger.ROOT_LOGGER.cannotFindOrImportInflowTransaction(xid, work, xae);
+        } catch (InvalidTransactionException ite) {
+            throw TransactionLogger.ROOT_LOGGER.importedInflowTransactionIsInactive(xid, work, ite);
+        } catch (SystemException se) {
+            throw TransactionLogger.ROOT_LOGGER.cannotResumeInflowTransactionUnexpectedError(transaction, work, se);
+        }
+    }
+
+    /**
+     * <p>
+     * Suspending transaction and canceling the work.
+     * <p>
+     * Suspend transaction has to be called on the wildfly transaction manager
+     * and the we delegate work cancellation to {@link JBossXATerminator}.<br>
+     * First we have to cancel the work for jboss terminator would not work with
+     * suspended transaction.
+     */
+    @Override
+    public void endWork(Work work, Xid xid) {
+        jbossXATerminator.cancelWork(work, xid);
+
+        try {
+            ContextTransactionManager.getInstance().suspend();
+        } catch (SystemException se) {
+            throw TransactionLogger.ROOT_LOGGER.cannotSuspendInflowTransactionUnexpectedError(work, se);
+        }
+    }
+
+    /**
+     * <p>
+     * Calling {@link JBossXATerminator} to cancel the work for us.
+     * <p>
+     * There should not be need any action to be processed by wildfly transaction client.
+     */
+    @Override
+    public void cancelWork(Work work, Xid xid) {
+        jbossXATerminator.cancelWork(work, xid);
+    }
+
+}

--- a/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
+++ b/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
@@ -27,8 +27,11 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
 
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkCompletedException;
 import javax.transaction.Synchronization;
 import javax.transaction.Transaction;
+import javax.transaction.xa.Xid;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
@@ -234,5 +237,17 @@ public interface TransactionLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 34, value = "relative_to property of the object-store is set to the default value with jboss.server.data.dir")
     void objectStoreRelativeToIsSetToDefault();
+
+    @Message(id = 35, value = "Cannot find or import inflow transaction for xid %s and work %s")
+    WorkCompletedException cannotFindOrImportInflowTransaction(Xid xid, Work work, @Cause Exception e);
+
+    @Message(id = 36, value = "Imported jca inflow transaction with xid %s of work %s is inactive")
+    WorkCompletedException importedInflowTransactionIsInactive(Xid xid, Work work, @Cause Exception e);
+
+    @Message(id = 37, value = "Unexpected error on resuming transaction %s for work %s")
+    WorkCompletedException cannotResumeInflowTransactionUnexpectedError(Transaction txn, Work work, @Cause Exception e);
+
+    @Message(id = 38, value = "Unexpected error on suspending transaction for work %s")
+    RuntimeException cannotSuspendInflowTransactionUnexpectedError(Work txn, @Cause Exception e);
 
 }

--- a/transactions/src/main/java/org/jboss/as/txn/service/JBossContextXATerminatorService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/JBossContextXATerminatorService.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.service;
+
+import org.jboss.as.txn.integration.JBossContextXATerminator;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.tm.JBossXATerminator;
+import org.wildfly.transaction.client.LocalTransactionContext;
+
+/**
+ * The XATerminator service for wildfly transaction client XATerminator.
+ *
+ * @author <a href="mailto:ochaloup@redhat.com">Ondrej Chaloupka</a>
+ */
+public final class JBossContextXATerminatorService implements Service<JBossContextXATerminator> {
+
+    private volatile JBossContextXATerminator value;
+
+    private final InjectedValue<JBossXATerminator> jbossXATerminatorInjector = new InjectedValue<>();
+    private final InjectedValue<LocalTransactionContext> localTransactionContextInjector = new InjectedValue<>();
+
+    public void start(final StartContext context) throws StartException {
+        this.value = new JBossContextXATerminator(
+            localTransactionContextInjector.getValue(), jbossXATerminatorInjector.getValue());
+    }
+
+    public void stop(final StopContext context) {
+        this.value = null;
+    }
+
+    public InjectedValue<LocalTransactionContext> getLocalTransactionContextInjector() {
+        return localTransactionContextInjector;
+    }
+
+
+    public InjectedValue<JBossXATerminator> getJBossXATerminatorInjector() {
+        return jbossXATerminatorInjector;
+    }
+
+    public JBossContextXATerminator getValue() throws IllegalStateException {
+        return TxnServices.notNull(value);
+    }
+
+}

--- a/transactions/src/main/java/org/jboss/as/txn/service/TransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TransactionManagerService.java
@@ -67,7 +67,7 @@ public class TransactionManagerService extends AbstractService<TransactionManage
     public void start(final StartContext context) throws StartException {
         final UserTransactionRegistry registry = registryInjector.getValue();
 
-        LocalTransactionContext.getCurrent().registerCreationListener(txn -> txn.registerAssociationListener(new AssociationListener() {
+        LocalTransactionContext.getCurrent().registerCreationListener((txn, createdBy) -> txn.registerAssociationListener(new AssociationListener() {
             private final AtomicBoolean first = new AtomicBoolean();
             public void associationChanged(final AbstractTransaction t, final boolean a) {
                 if (a && first.compareAndSet(false, true)) registry.userTransactionStarted();

--- a/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
@@ -65,6 +65,9 @@ public final class TxnServices {
 
     public static final ServiceName JBOSS_TXN_HTTP_REMOTE_TRANSACTION_SERVICE = JBOSS_TXN.append("service", "http-remote");
 
+    public static final ServiceName JBOSS_TXN_CONTEXT_XA_TERMINATOR = JBOSS_TXN.append("JBossContextXATerminator");
+
+
     public static <T> T notNull(T value) {
         if (value == null) throw TransactionLogger.ROOT_LOGGER.serviceNotStarted();
         return value;


### PR DESCRIPTION
These are fixes for integration of wildfly transaciton client with JTA and JCA layers.

After discussion with David and Flavia I created a new wrapper `JBoss XATerminator` class which is configured to be used in JCA. The new terminator then delegates calls to wildfly client `ContextXATerminator` and inner Narayana calls are mimicked or passed to Naryana's `JBossXATerminator` implementations.

https://issues.jboss.org/browse/JBEAP-8993
https://issues.jboss.org/browse/WFLY-8275