### PR TITLE
[JBTM-3106] fixing test failures on Narayana CDI changes

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/tx/timeout/TxTimeoutTimerServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/tx/timeout/TxTimeoutTimerServiceTestCase.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +45,6 @@ public class TxTimeoutTimerServiceTestCase {
     public static Archive<?> deploy() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "Jar.jar");
         jar.addPackage(TxTimeoutTimerServiceTestCase.class.getPackage());
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts \n"), "MANIFEST.MF");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/DefaultTransactionTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/DefaultTransactionTimeoutTestCase.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,9 +41,6 @@ public class DefaultTransactionTimeoutTestCase {
     @Deployment
     public static Archive<?> createDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test-ejb-cmt-timeout.jar");
-        // a manifest must have a \n at the end or else it'll not be properly process
-        // here we hack one in place
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts \n"), "MANIFEST.MF");
         jar.addClass(BeanWithTimeoutValue.class);
         jar.addClass(TimeoutRemoteView.class);
         jar.addClass(TimeoutLocalView.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/TransactionTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/TransactionTimeoutTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,9 +40,6 @@ public class TransactionTimeoutTestCase {
     @Deployment
     public static Archive<?> createDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test-ejb-cmt-timeout.jar");
-        // a manifest must have a \n at the end or else it'll not be properly process
-        // here we hack one in place
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts \n"), "MANIFEST.MF");
         jar.addClass(BeanWithTimeoutValue.class);
         jar.addClass(TimeoutRemoteView.class);
         jar.addClass(TimeoutLocalView.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
@@ -36,7 +36,7 @@ public class TimerEJBRuntimeNameTestCase extends AbstractRuntimeTestCase {
     private static final Logger log = Logger.getLogger(TimerEJBRuntimeNameTestCase.class);
     private static final String EJB_TYPE = EJBManagementUtil.SINGLETON;
     private static final Package BEAN_PACKAGE = PointLessBean.class.getPackage();
-    private static final Class BEAN_CLASS = PointlessInterface.class;
+    private static final Class<?> BEAN_CLASS = PointlessInterface.class;
     private static final String BEAN_NAME = "POINT";
 
     private static final String RT_MODULE_NAME = "nooma-nooma6-" + EJB_TYPE;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/ejb/singleton/timer/PointLessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/ejb/singleton/timer/PointLessBean.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.test.integration.management.deploy.runtime.ejb.singleton.timer;
 
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
 import javax.ejb.Singleton;
 import javax.ejb.Timeout;
@@ -35,8 +34,6 @@ import javax.ejb.TimerService;
 @Singleton(name = "POINT")
 public class PointLessBean implements PointlessInterface {
 
-    private static final int WAIT_TIME = 1;
-    private static final TimeUnit WAIT_UNIT = TimeUnit.SECONDS;
     private static final TimerConfig TIMER_CONFIG = new TimerConfig("Eye Candy", true);
 
     private int count = 0;


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3106

it happens to have issues to inject the Narayana CDI interceptor when
the tests forces using the internal org.jboss.jts module.
This is not needed as we use the WFTC project now and we don't need
to use the Narayana classes directly in the tests.
As Narayana CDI extension is not used then the CDI was not loaded
and happens the CDI was not capable to find it

```
[ERROR] org.jboss.as.test.integration.ejb.transaction.cmt.timeout.TransactionTimeoutTestCase  Time elapsed: 0.175 s  <<< ERROR!
org.jboss.arquillian.container.spi.client.container.DeploymentException:
Cannot deploy test-ejb-cmt-timeout.jar: {"WFLYCTL0062: Composite operation failed and was rolled back. Steps that failed:" => {"Operation step-1" => {"WFLYCTL0080: Failed services" => {"jboss.deployment.unit.\"test-ejb-cmt-timeout.jar\".WeldStartService" => "Failed to start service
    Caused by: org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type TransactionExtension with qualifiers @Default
  at injection point [BackedAnnotatedField] @Inject private com.arjuna.ats.jta.cdi.transactional.TransactionalInterceptorBase.extension
  at com.arjuna.ats.jta.cdi.transactional.TransactionalInterceptorBase.extension(TransactionalInterceptorBase.java:0)
"}}}}
```