### PR TITLE
Revert "(AMS CI fix) igroring ApplicationContextLifecycleTestCase"

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
@@ -33,7 +33,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,7 +48,6 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
  * @author emmartins
  */
 @RunWith(Arquillian.class)
-@Ignore
 public class ApplicationContextLifecycleTestCase {
 
     private static final String TEST_BEANS_LIB_JAR = "TEST_BEANS_LIB_JAR";


### PR DESCRIPTION
Jira does not explain why this test was disabled
(https://issues.redhat.com/issues/?jql=text~ApplicationContextLifecycleTestCase%20AND%20project%3DJBTM)