### PR TITLE
Add stork module for LRA (required for JBTM-3987)

### DIFF
--- a/boms/common-expansion/pom.xml
+++ b/boms/common-expansion/pom.xml
@@ -1066,6 +1066,44 @@
             </dependency>
 
             <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-api</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-core</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.stork</groupId>
+                <artifactId>stork-service-discovery-static-list</artifactId>
+                <version>${version.io.smallrye.smallrye-stork}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-amqp-client</artifactId>
                 <version>${version.io.vertx.vertx}</version>

--- a/galleon-pack/galleon-shared/pom.xml
+++ b/galleon-pack/galleon-shared/pom.xml
@@ -115,6 +115,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-static-list</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-jwt</artifactId>
             <exclusions>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/stork/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/io/smallrye/stork/main/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright The WildFly Authors
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="io.smallrye.stork">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${io.smallrye.stork:stork-core}"/>
+        <artifact name="${io.smallrye.stork:stork-api}"/>
+        <artifact name="${io.smallrye.stork:stork-service-discovery-static-list}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.eclipse.microprofile.config.api" />
+        <module name="jakarta.enterprise.api" />
+        <module name="jakarta.annotation.api" />
+        <module name="org.jboss.logging" />
+        <module name="io.smallrye.config" services="import"/>
+    </dependencies>
+</module>

--- a/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
+++ b/galleon-pack/galleon-shared/src/main/resources/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml
@@ -30,6 +30,7 @@
     <!-- narayana-lra -->
     <module name="org.eclipse.microprofile.config.api"/>
     <module name="io.smallrye.config"/>
+    <module name="io.smallrye.stork"/>
 
     <!-- Required for proper creation of proxies for CDI beans originating from this module -->    
     <module name="org.jboss.weld.api"/>

--- a/microprofile/lra/participant/pom.xml
+++ b/microprofile/lra/participant/pom.xml
@@ -64,6 +64,18 @@
       <artifactId>lra-proxy-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.stork</groupId>
+      <artifactId>stork-service-discovery-static-list</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>

--- a/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
+++ b/microprofile/lra/participant/src/main/java/org/wildfly/extension/microprofile/lra/participant/deployment/LRAParticipantDeploymentDependencyProcessor.java
@@ -46,6 +46,7 @@ public class LRAParticipantDeploymentDependencyProcessor implements DeploymentUn
         lraParticipantDependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
         moduleSpecification.addSystemDependency(lraParticipantDependency);
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "io.smallrye.jandex").setImportServices(true).build());
+        moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "io.smallrye.stork").setImportServices(true).build());
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.jboss.as.weld.common").setImportServices(true).build());
         moduleSpecification.addSystemDependency(ModuleDependency.Builder.of(moduleLoader, "org.jboss.resteasy.resteasy-cdi").setImportServices(true).build());
 

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
         <version.io.smallrye.smallrye-mutiny-vertx>3.17.1</version.io.smallrye.smallrye-mutiny-vertx>
         <version.io.smallrye.smallrye-mutiny-zero>1.1.1</version.io.smallrye.smallrye-mutiny-zero>
         <version.io.smallrye.smallrye-opentelemetry>2.9.2</version.io.smallrye.smallrye-opentelemetry>
+        <version.io.smallrye.smallrye-stork>2.7.3</version.io.smallrye.smallrye-stork>
         <version.io.smallrye.smallrye-reactive-messaging>4.25.0</version.io.smallrye.smallrye-reactive-messaging>
         <version.io.undertow.jastow>2.2.8.Final</version.io.undertow.jastow>
         <version.io.vertx.vertx>4.5.15</version.io.vertx.vertx>
@@ -485,7 +486,7 @@
         <version.org.jboss.metadata>16.1.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.1.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.2.2.Final</version.org.jboss.narayana>
-        <version.org.jboss.narayana.lra>1.0.1.Final</version.org.jboss.narayana.lra>
+        <version.org.jboss.narayana.lra>1.0.2.Final-SNAPSHOT</version.org.jboss.narayana.lra>
         <version.org.jboss.openjdk-orb>10.1.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>


### PR DESCRIPTION
This change is required for running the MP-LRA testsuite (https://issues.redhat.com/browse/JBTM-3987 added a dependency on SmallRye Stork). It is required for jbosstm/lra#50