### PR TITLE
Reset the version of Narayana LRA back to 1.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@
         <version.org.jboss.metadata>16.1.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>2.1.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>7.2.2.Final</version.org.jboss.narayana>
-        <version.org.jboss.narayana.lra>1.0.2.Final-SNAPSHOT</version.org.jboss.narayana.lra>
+        <version.org.jboss.narayana.lra>1.0.1.Final</version.org.jboss.narayana.lra>
         <version.org.jboss.openjdk-orb>10.1.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>


### PR DESCRIPTION
Using the snapshot version causes the Narayana build to fail: https://github.com/tomjenkinson/narayana/actions/runs/15850027491/job/44680987225